### PR TITLE
Refactor revising the getcurrentconfigquery handler

### DIFF
--- a/src/EnvironmentGateway/EnvironmentGateway.Api/Endpoints/CurrentConfig/Get.cs
+++ b/src/EnvironmentGateway/EnvironmentGateway.Api/Endpoints/CurrentConfig/Get.cs
@@ -15,7 +15,8 @@ public class Get : IEndpoint
 
                 var result = await handler.Handle(query, cancellationToken);
 
-                return result.IsSuccess ? Results.Ok(result.Value) : Results.NotFound();
+                return result.IsSuccess ? Results.Ok(result.Value) 
+                    : Results.NotFound(result.Error);
             })
             .RequireAuthorization();
     }

--- a/src/EnvironmentGateway/EnvironmentGateway.Application/GatewayConfigs/GetCurrentConfig/CurrentConfigMapper.cs
+++ b/src/EnvironmentGateway/EnvironmentGateway.Application/GatewayConfigs/GetCurrentConfig/CurrentConfigMapper.cs
@@ -1,0 +1,87 @@
+﻿namespace EnvironmentGateway.Application.GatewayConfigs.GetCurrentConfig;
+
+internal sealed class CurrentConfigMapper
+{
+    internal static CurrentConfigResponse MapCurrentConfigResponse(
+        CurrentConfigBaseData? currentConfigBaseData,
+        List<CurrentRoute> currentRoutes, 
+        List<CurrentCluster> currentClusters)
+    {
+        var response = new CurrentConfigResponse()
+        {
+            Id = currentConfigBaseData.Id,
+            Name = currentConfigBaseData.GatewayConfigName,
+            IsCurrentConfig = currentConfigBaseData.IsCurrentConfig,
+            Routes = new List<RouteResponse>(),
+            Clusters = new List<ClusterResponse>()
+        };
+        
+        currentRoutes.ForEach(route =>
+        {
+            var transforms = new RouteTransformsResponse()
+            {
+                Id = route.Transforms.Id, 
+                Transforms = route.Transforms.TransformItems
+            };
+            response.Routes.Add(new RouteResponse()
+            {
+                Id = route.Id,
+                RouteName = route.RouteName,
+                ClusterName = route.ClusterName,
+                Match = new RouteMatchResponse(){ Path = route.MatchPath },
+                Transforms = transforms
+            });
+        });
+        
+        currentClusters.ForEach(cluster =>
+        {
+            var destinations = new Dictionary<string, DestinationResponse>();
+            cluster.Destinations.ForEach(destination =>
+            {
+                var key = destination.DestinationName;
+                var value = new DestinationResponse()
+                {
+                    Id = destination.Id,
+                    DestinationName = destination.DestinationName,
+                    Address = destination.Address
+                };
+                destinations.Add(key, value);
+            });
+            response.Clusters.Add(new ClusterResponse()
+            {
+                Id = cluster.Id, 
+                ClusterName = cluster.ClusterName, 
+                Destinations = destinations
+            });
+        });
+        return response;
+    }
+    
+    internal sealed record CurrentConfigBaseData(
+        Guid Id,
+        string GatewayConfigName,
+        bool IsCurrentConfig);
+
+    internal sealed record CurrentRoute(
+        Guid Id,
+        string RouteName,
+        string ClusterName,
+        string MatchPath,
+        Transforms Transforms);
+    
+    internal sealed record Transforms(
+        Guid Id,
+        List<Dictionary<string, string>> TransformItems);
+    
+    internal sealed record TransformItem(string Key, string Value);
+
+    internal sealed record CurrentCluster(
+        Guid Id,
+        string ClusterName,
+        List<Destination> Destinations);
+
+    internal sealed record Destination(
+        Guid Id,
+        string DestinationName,
+        string Address);
+}

--- a/src/EnvironmentGateway/EnvironmentGateway.Application/GatewayConfigs/GetCurrentConfig/CurrentConfigMapper.cs
+++ b/src/EnvironmentGateway/EnvironmentGateway.Application/GatewayConfigs/GetCurrentConfig/CurrentConfigMapper.cs
@@ -2,7 +2,7 @@
 
 internal sealed class CurrentConfigMapper
 {
-    internal static CurrentConfigResponse MapCurrentConfigResponse(
+    internal static CurrentConfigResponse Map(
         CurrentConfigBaseData? currentConfigBaseData,
         List<CurrentRoute> currentRoutes, 
         List<CurrentCluster> currentClusters)

--- a/src/EnvironmentGateway/EnvironmentGateway.Application/GatewayConfigs/GetCurrentConfig/GetCurrentConfigQueryHandler.cs
+++ b/src/EnvironmentGateway/EnvironmentGateway.Application/GatewayConfigs/GetCurrentConfig/GetCurrentConfigQueryHandler.cs
@@ -2,8 +2,6 @@
 using EnvironmentGateway.Application.Abstractions.Messaging;
 using EnvironmentGateway.Domain.Abstractions;
 using EnvironmentGateway.Domain.GatewayConfigs;
-using EnvironmentGateway.Domain.Routes;
-using EnvironmentGateway.Domain.Routes.Transforms;
 using Microsoft.EntityFrameworkCore;
 
 namespace EnvironmentGateway.Application.GatewayConfigs.GetCurrentConfig;
@@ -24,17 +22,17 @@ internal sealed class GetCurrentConfigQueryHandler(IEnvironmentGatewayDbContext 
             return Result.Failure<CurrentConfigResponse>(GatewayConfigErrors.CurrentConfigNotFound);
         }
 
-        CurrentConfigBaseData currentConfigBaseData = await GetCurrentConfigBaseData(cancellationToken);
+        CurrentConfigMapper.CurrentConfigBaseData currentConfigBaseData = await GetCurrentConfigBaseData(cancellationToken);
         
         var currentRoutes = await context
             .Routes
             .Where(route => route.GatewayConfigId == currentConfigBaseData.Id)
-            .Select(route => new CurrentRoute(
+            .Select(route => new CurrentConfigMapper.CurrentRoute(
                     route.Id,
                     route.RouteName.Value,
                     route.ClusterName.Value,
                     route.Match.Path.Value,
-                    new Transforms(
+                    new CurrentConfigMapper.Transforms(
                         route.Transforms.Id,
                         route.Transforms.Transforms
                             .Select(item => new Dictionary<string, string>{{item.Key, item.Value}})
@@ -46,12 +44,12 @@ internal sealed class GetCurrentConfigQueryHandler(IEnvironmentGatewayDbContext 
         var currentClusters = await context
             .Clusters
             .Where(cluster => cluster.GatewayConfigId == currentConfigBaseData.Id)
-            .Select(cluster => new CurrentCluster(
+            .Select(cluster => new CurrentConfigMapper.CurrentCluster(
                 cluster.Id,
                 cluster.ClusterName.Value,
-                new List<Destination>(
+                new List<CurrentConfigMapper.Destination>(
                     cluster.Destinations
-                        .Select(destination => new Destination(
+                        .Select(destination => new CurrentConfigMapper.Destination(
                             destination.Id,
                             destination.DestinationName.Value,
                             destination.Address.Value)
@@ -62,106 +60,29 @@ internal sealed class GetCurrentConfigQueryHandler(IEnvironmentGatewayDbContext 
             .ToListAsync(cancellationToken);
         
 
-        CurrentConfigResponse response = MapCurrentConfigResponse(currentConfigBaseData, currentRoutes, currentClusters);
+        CurrentConfigResponse response = CurrentConfigMapper.MapCurrentConfigResponse(currentConfigBaseData, currentRoutes, currentClusters);
 
 
         return response;
     }
 
-    private static CurrentConfigResponse MapCurrentConfigResponse(CurrentConfigBaseData? currentConfigBaseData,
-        List<CurrentRoute> currentRoutes, List<CurrentCluster> currentClusters)
-    {
-        var response = new CurrentConfigResponse()
-        {
-            Id = currentConfigBaseData.Id,
-            Name = currentConfigBaseData.GatewayConfigName,
-            IsCurrentConfig = currentConfigBaseData.IsCurrentConfig,
-            Routes = new List<RouteResponse>(),
-            Clusters = new List<ClusterResponse>()
-        };
-        
-        currentRoutes.ForEach(route =>
-        {
-            var transforms = new RouteTransformsResponse()
-            {
-                Id = route.Transforms.Id, 
-                Transforms = route.Transforms.TransformItems
-            };
-            response.Routes.Add(new RouteResponse()
-            {
-                Id = route.Id,
-                RouteName = route.RouteName,
-                ClusterName = route.ClusterName,
-                Match = new RouteMatchResponse(){ Path = route.MatchPath },
-                Transforms = transforms
-            });
-        });
-        
-        currentClusters.ForEach(cluster =>
-        {
-            var destinations = new Dictionary<string, DestinationResponse>();
-            cluster.Destinations.ForEach(destination =>
-            {
-                var key = destination.DestinationName;
-                var value = new DestinationResponse()
-                {
-                    Id = destination.Id,
-                    DestinationName = destination.DestinationName,
-                    Address = destination.Address
-                };
-                destinations.Add(key, value);
-            });
-            response.Clusters.Add(new ClusterResponse()
-            {
-                Id = cluster.Id, 
-                ClusterName = cluster.ClusterName, 
-                Destinations = destinations
-            });
-        });
-        return response;
-    }
+    
 
-    private async Task<CurrentConfigBaseData?> GetCurrentConfigBaseData(CancellationToken cancellationToken)
+    private async Task<CurrentConfigMapper.CurrentConfigBaseData?> GetCurrentConfigBaseData(CancellationToken cancellationToken)
     {
-        CurrentConfigBaseData? currentConfigBaseData = await context
+        CurrentConfigMapper.CurrentConfigBaseData? currentConfigBaseData = await context
             .Database
-            .SqlQuery<CurrentConfigBaseData>($"""
-                                      SELECT 
-                                          gc.id AS id,
-                                          gc.name_value AS gateway_config_name,
-                                          gc.is_current_config AS is_current_config
-                                      FROM gateway_configs gc
-                                      WHERE gc.is_current_config = true
-                                      """)
+            .SqlQuery<CurrentConfigMapper.CurrentConfigBaseData>($"""
+                                                                  SELECT 
+                                                                      gc.id AS id,
+                                                                      gc.name_value AS gateway_config_name,
+                                                                      gc.is_current_config AS is_current_config
+                                                                  FROM gateway_configs gc
+                                                                  WHERE gc.is_current_config = true
+                                                                  """)
             .SingleOrDefaultAsync(cancellationToken);
         return currentConfigBaseData;
     }
 
-    private sealed record CurrentConfigBaseData(
-        Guid Id,
-        string GatewayConfigName,
-        bool IsCurrentConfig);
-
-    private sealed record CurrentRoute(
-        Guid Id,
-        string RouteName,
-        string ClusterName,
-        string MatchPath,
-        Transforms Transforms);
     
-    private sealed record Transforms(
-        Guid Id,
-        List<Dictionary<string, string>> TransformItems);
-    
-    private sealed record TransformItem(string Key, string Value);
-
-    private sealed record CurrentCluster(
-        Guid Id,
-        string ClusterName,
-        List<Destination> Destinations);
-
-    private sealed record Destination(
-        Guid Id,
-        string DestinationName,
-        string Address);
 }

--- a/src/EnvironmentGateway/EnvironmentGateway.Application/GatewayConfigs/GetCurrentConfig/GetCurrentConfigQueryHandler.cs
+++ b/src/EnvironmentGateway/EnvironmentGateway.Application/GatewayConfigs/GetCurrentConfig/GetCurrentConfigQueryHandler.cs
@@ -60,7 +60,7 @@ internal sealed class GetCurrentConfigQueryHandler(IEnvironmentGatewayDbContext 
             .ToListAsync(cancellationToken);
         
 
-        CurrentConfigResponse response = CurrentConfigMapper.MapCurrentConfigResponse(currentConfigBaseData, currentRoutes, currentClusters);
+        CurrentConfigResponse response = CurrentConfigMapper.Map(currentConfigBaseData, currentRoutes, currentClusters);
 
 
         return response;

--- a/src/EnvironmentGateway/EnvironmentGateway.Domain/GatewayConfigs/GatewayConfigErrors.cs
+++ b/src/EnvironmentGateway/EnvironmentGateway.Domain/GatewayConfigs/GatewayConfigErrors.cs
@@ -7,4 +7,10 @@ public static class GatewayConfigErrors
     public static readonly Error CreateNewConfigFailed = new(
         "CreateNewConfigFailed", 
         "Failed to create new configuration.");
+    
+    public static readonly Error CurrentConfigNotFound = new(
+        "CurrentConfigNotFound", 
+        "No valid gateway configuration found in the database. Either no gatewayConfig exists, or none is marked as isCurrentConfig = true.");
+
+
 }

--- a/src/EnvironmentGateway/EnvironmentGateway.Domain/Routes/Transforms/RouteTransforms.cs
+++ b/src/EnvironmentGateway/EnvironmentGateway.Domain/Routes/Transforms/RouteTransforms.cs
@@ -14,7 +14,7 @@ public sealed class RouteTransforms : Entity
     
     public Guid RouteId { get; init; }
     public Route Route { get; init; } = null!;
-    public List<Transform> Transforms { get; private set; } = new();
+    public List<TransformsItem> Transforms { get; private set; } = new();
 
     public static RouteTransforms Create()
     {
@@ -23,7 +23,7 @@ public sealed class RouteTransforms : Entity
     
     public void AddTransform(string key, string value)
     {
-        var transform = new Transform(key, value);
+        var transform = new TransformsItem(key, value);
         Transforms.Add(transform);
     }
 }

--- a/src/EnvironmentGateway/EnvironmentGateway.Domain/Routes/Transforms/Transform.cs
+++ b/src/EnvironmentGateway/EnvironmentGateway.Domain/Routes/Transforms/Transform.cs
@@ -1,3 +1,0 @@
-﻿namespace EnvironmentGateway.Domain.Routes.Transforms;
-
-public sealed record Transform(string Key, string Value);

--- a/src/EnvironmentGateway/EnvironmentGateway.Domain/Routes/Transforms/TransformsItem.cs
+++ b/src/EnvironmentGateway/EnvironmentGateway.Domain/Routes/Transforms/TransformsItem.cs
@@ -1,0 +1,3 @@
+﻿namespace EnvironmentGateway.Domain.Routes.Transforms;
+
+public sealed record TransformsItem(string Key, string Value);

--- a/src/EnvironmentGateway/EnvironmentGateway.Infrastructure/Migrations/EnvironmentGatewayDbContextModelSnapshot.cs
+++ b/src/EnvironmentGateway/EnvironmentGateway.Infrastructure/Migrations/EnvironmentGatewayDbContextModelSnapshot.cs
@@ -262,7 +262,7 @@ namespace environmentgateway.infrastructure.Migrations
                         .IsRequired()
                         .HasConstraintName("fk_route_transforms_routes_route_id");
 
-                    b.OwnsMany("EnvironmentGateway.Domain.Routes.Transforms.Transform", "Transforms", b1 =>
+                    b.OwnsMany("EnvironmentGateway.Domain.Routes.Transforms.TransformsItem", "Transforms", b1 =>
                         {
                             b1.Property<Guid>("RouteTransformsId")
                                 .HasColumnType("uuid")


### PR DESCRIPTION
This pull request refactors how the current gateway configuration is retrieved and mapped, improves error handling, and updates the transforms model for routes. The main changes include introducing a dedicated mapper for the current config response, removing raw SQL queries in favor of LINQ-based entity access, enhancing error reporting, and updating the transforms implementation to use a new record type.

**Current Configuration Retrieval and Mapping:**

- Introduced `CurrentConfigMapper` in `CurrentConfigMapper.cs` to encapsulate mapping logic for the current configuration response, improving code organization and readability.
- Refactored `GetCurrentConfigQueryHandler` to use LINQ queries instead of raw SQL for retrieving routes and clusters, and delegated response mapping to `CurrentConfigMapper`. This simplifies the handler and reduces code duplication.

**Error Handling Improvements:**

- Added a new error type `CurrentConfigNotFound` in `GatewayConfigErrors` to provide clearer error messages when no current configuration is found.
- Updated endpoint in `Get.cs` to return the error message in the response body when the current config is not found.

**Transforms Model Update:**

- Replaced the `Transform` record with a new `TransformsItem` record for route transforms, updating all usages and entity configurations accordingly. [[1]](diffhunk://#diff-3cd615bc6db7657945df27434ae7b60ff15634f89d541f8059044c9ea5237e04L17-R17) [[2]](diffhunk://#diff-3cd615bc6db7657945df27434ae7b60ff15634f89d541f8059044c9ea5237e04L26-R26) [[3]](diffhunk://#diff-25c988eb1c7fa1e8042d665ec50b06d34f32411fc76f292998ac31a1d3e6a251L1-L3) [[4]](diffhunk://#diff-1f2b19121c4eb9c304a358759180171dca5f7afc00d6bf036ef33ad59160b2daR1-R3) [[5]](diffhunk://#diff-756e99937d1903f94185f9046f8d9f8f21a2920b54bcc2b816ce10fff8df5537L265-R265)