### PR TITLE
73 implementing change destination name in the backend

### DIFF
--- a/src/EnvironmentGateway/EnvironmentGateway.Api/Endpoints/Destinations/ChangeDestinationName/ChangeDestinationName.cs
+++ b/src/EnvironmentGateway/EnvironmentGateway.Api/Endpoints/Destinations/ChangeDestinationName/ChangeDestinationName.cs
@@ -1,36 +1,37 @@
 ﻿using EnvironmentGateway.Api.GatewayConfiguration.Abstractions;
 using EnvironmentGateway.Application.Abstractions.Messaging;
-using EnvironmentGateway.Application.Destinations.ChangeDestinationAddress;
+using EnvironmentGateway.Application.Destinations.ChangeDestinationName;
 
-namespace EnvironmentGateway.Api.Endpoints.Destinations.ChangeDestinationAddress;
+namespace EnvironmentGateway.Api.Endpoints.Destinations.ChangeDestinationName;
 
-public class ChangeDestinationAddress : IEndpoint
+public class ChangeDestinationName : IEndpoint
 {
     public void MapEndpoint(IEndpointRouteBuilder app)
     {
-        app.MapPut("change-destination-address", 
+        app.MapPut("change-destination-name",
                 async (
-                    ChangeDestinationAddressRequest request,
-                    ICommandHandler<ChangeDestinationAddressCommand> commandHandler,
+                    ChangeDestinationNameRequest request,
+                    ICommandHandler<ChangeDestinationNameCommand> commandHandler,
                     IRuntimeConfigurator runtimeConfigurator,
                     CancellationToken cancellationToken) =>
                 {
-                    var command = new ChangeDestinationAddressCommand(
+                    var command = new ChangeDestinationNameCommand(
                         request.ClusterId,
                         request.DestinationId,
-                        request.Address);
-
+                        request.DestinationName);
+                    
                     var result = await commandHandler.Handle(command, cancellationToken);
-
+                    
                     if (result.IsFailure)
                     {
                         return Results.BadRequest(result.Error);
                     }
-
+                    
                     var updateResult = await runtimeConfigurator.UpdateProxyConfig();
-
+                    
                     return Results.Ok(updateResult.IsSuccess);
                 }
+
             )
             .RequireAuthorization();
     }

--- a/src/EnvironmentGateway/EnvironmentGateway.Api/Endpoints/Destinations/ChangeDestinationName/ChangeDestinationNameRequest.cs
+++ b/src/EnvironmentGateway/EnvironmentGateway.Api/Endpoints/Destinations/ChangeDestinationName/ChangeDestinationNameRequest.cs
@@ -1,0 +1,8 @@
+﻿using System.Globalization;
+
+namespace EnvironmentGateway.Api.Endpoints.Destinations.ChangeDestinationName;
+
+public sealed record ChangeDestinationNameRequest(
+    Guid ClusterId,
+    Guid DestinationId,
+    string DestinationName);

--- a/src/EnvironmentGateway/EnvironmentGateway.Api/Endpoints/Destinations/ChangeDestinationName/ChangeDestinationNameRequest.cs
+++ b/src/EnvironmentGateway/EnvironmentGateway.Api/Endpoints/Destinations/ChangeDestinationName/ChangeDestinationNameRequest.cs
@@ -1,6 +1,4 @@
-﻿using System.Globalization;
-
-namespace EnvironmentGateway.Api.Endpoints.Destinations.ChangeDestinationName;
+﻿namespace EnvironmentGateway.Api.Endpoints.Destinations.ChangeDestinationName;
 
 public sealed record ChangeDestinationNameRequest(
     Guid ClusterId,

--- a/src/EnvironmentGateway/EnvironmentGateway.Application/DependencyInjection.cs
+++ b/src/EnvironmentGateway/EnvironmentGateway.Application/DependencyInjection.cs
@@ -1,6 +1,5 @@
 ﻿using EnvironmentGateway.Application.Abstractions.Behaviors;
 using EnvironmentGateway.Application.Abstractions.Messaging;
-using EnvironmentGateway.Application.Destinations.UpdateDestination;
 using EnvironmentGateway.Domain.Abstractions;
 using FluentValidation;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/EnvironmentGateway/EnvironmentGateway.Application/Destinations/ChangeDestinationAddress/ChangeDestinationAddressCommand.cs
+++ b/src/EnvironmentGateway/EnvironmentGateway.Application/Destinations/ChangeDestinationAddress/ChangeDestinationAddressCommand.cs
@@ -1,6 +1,7 @@
-﻿using EnvironmentGateway.Application.Abstractions.Messaging;
+﻿
+using EnvironmentGateway.Application.Abstractions.Messaging;
 
-namespace EnvironmentGateway.Application.Destinations.UpdateDestination;
+namespace EnvironmentGateway.Application.Destinations.ChangeDestinationAddress;
 
 public sealed record ChangeDestinationAddressCommand(
     Guid ClusterId,

--- a/src/EnvironmentGateway/EnvironmentGateway.Application/Destinations/ChangeDestinationAddress/ChangeDestinationAddressCommandHandler.cs
+++ b/src/EnvironmentGateway/EnvironmentGateway.Application/Destinations/ChangeDestinationAddress/ChangeDestinationAddressCommandHandler.cs
@@ -2,7 +2,7 @@
 using EnvironmentGateway.Domain.Abstractions;
 using EnvironmentGateway.Domain.Clusters.Destinations;
 
-namespace EnvironmentGateway.Application.Destinations.UpdateDestination;
+namespace EnvironmentGateway.Application.Destinations.ChangeDestinationAddress;
 
 internal sealed class ChangeDestinationAddressCommandHandler(
     IDestinationRepository destinationRepository,

--- a/src/EnvironmentGateway/EnvironmentGateway.Application/Destinations/ChangeDestinationAddress/ChangeDestinationAddressCommandValidator.cs
+++ b/src/EnvironmentGateway/EnvironmentGateway.Application/Destinations/ChangeDestinationAddress/ChangeDestinationAddressCommandValidator.cs
@@ -3,7 +3,7 @@ using FluentValidation;
 
 namespace EnvironmentGateway.Application.Destinations.ChangeDestinationAddress;
 
-public class ChangeDestinationAddressCommandValidator : AbstractValidator<ChangeDestinationAddressCommand>
+internal sealed class ChangeDestinationAddressCommandValidator : AbstractValidator<ChangeDestinationAddressCommand>
 {
     private const string UrlPattern =
         @"^(https?|ftps?):\/\/(?:[a-zA-Z0-9]" +

--- a/src/EnvironmentGateway/EnvironmentGateway.Application/Destinations/ChangeDestinationAddress/ChangeDestinationAddressCommandValidator.cs
+++ b/src/EnvironmentGateway/EnvironmentGateway.Application/Destinations/ChangeDestinationAddress/ChangeDestinationAddressCommandValidator.cs
@@ -1,7 +1,7 @@
-﻿using FluentValidation;
-using System.Text.RegularExpressions;
+﻿using System.Text.RegularExpressions;
+using FluentValidation;
 
-namespace EnvironmentGateway.Application.Destinations.UpdateDestination;
+namespace EnvironmentGateway.Application.Destinations.ChangeDestinationAddress;
 
 public class ChangeDestinationAddressCommandValidator : AbstractValidator<ChangeDestinationAddressCommand>
 {

--- a/src/EnvironmentGateway/EnvironmentGateway.Application/Destinations/ChangeDestinationName/ChangeDestinationNameCommand.cs
+++ b/src/EnvironmentGateway/EnvironmentGateway.Application/Destinations/ChangeDestinationName/ChangeDestinationNameCommand.cs
@@ -1,0 +1,9 @@
+﻿using EnvironmentGateway.Application.Abstractions.Messaging;
+
+namespace EnvironmentGateway.Application.Destinations.ChangeDestinationName;
+
+public sealed record ChangeDestinationNameCommand(
+    Guid ClusterId,
+    Guid DestinationId,
+    string DestinationName)
+    : ICommand;

--- a/src/EnvironmentGateway/EnvironmentGateway.Application/Destinations/ChangeDestinationName/ChangeDestinationNameCommandHandler.cs
+++ b/src/EnvironmentGateway/EnvironmentGateway.Application/Destinations/ChangeDestinationName/ChangeDestinationNameCommandHandler.cs
@@ -1,0 +1,30 @@
+﻿using EnvironmentGateway.Application.Abstractions.Messaging;
+using EnvironmentGateway.Domain.Abstractions;
+using EnvironmentGateway.Domain.Clusters.Destinations;
+
+namespace EnvironmentGateway.Application.Destinations.ChangeDestinationName;
+
+internal sealed class ChangeDestinationNameCommandHandler(
+    IDestinationRepository destinationRepository,
+    IUnitOfWork unitOfWork)
+    : ICommandHandler<ChangeDestinationNameCommand>
+{
+    public async Task<Result> Handle(
+        ChangeDestinationNameCommand command, 
+        CancellationToken cancellationToken)
+    {
+        var destination = await destinationRepository
+            .GetByIdAsync(command.ClusterId, command.DestinationId, cancellationToken);
+        
+        if (destination is null)
+        {
+            return Result.Failure(DestinationErrors.NotFound);
+        }
+
+        destination.ChangeName(command.DestinationName);
+
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+
+        return Result.Success();
+    }
+}

--- a/src/EnvironmentGateway/EnvironmentGateway.Application/Destinations/ChangeDestinationName/ChangeDestinationNameValidator.cs
+++ b/src/EnvironmentGateway/EnvironmentGateway.Application/Destinations/ChangeDestinationName/ChangeDestinationNameValidator.cs
@@ -3,7 +3,7 @@ using FluentValidation;
 
 namespace EnvironmentGateway.Application.Destinations.ChangeDestinationName;
 
-public class ChangeDestinationNameValidator : AbstractValidator<ChangeDestinationNameCommand>
+internal sealed class ChangeDestinationNameValidator : AbstractValidator<ChangeDestinationNameCommand>
 {
     private const string UrlPattern = "^[A-Za-z0-9-]+$";
     

--- a/src/EnvironmentGateway/EnvironmentGateway.Application/Destinations/ChangeDestinationName/ChangeDestinationNameValidator.cs
+++ b/src/EnvironmentGateway/EnvironmentGateway.Application/Destinations/ChangeDestinationName/ChangeDestinationNameValidator.cs
@@ -1,0 +1,23 @@
+﻿using System.Text.RegularExpressions;
+using FluentValidation;
+
+namespace EnvironmentGateway.Application.Destinations.ChangeDestinationName;
+
+public class ChangeDestinationNameValidator : AbstractValidator<ChangeDestinationNameCommand>
+{
+    private const string UrlPattern = "^[A-Za-z0-9-]+$";
+    
+    public ChangeDestinationNameValidator()
+    {
+        RuleFor(x => x.DestinationName)
+            .NotEmpty()
+            .MaximumLength(100)
+            .Matches(UrlPattern, RegexOptions.IgnoreCase)
+            .WithMessage("Please enter a valid name for the destination.\n" +
+                        "Please make sure to follow these rules:\n" +
+                        "• The name may only contain letters, numbers, and the '-' character\n" +
+                        "• Do not use spaces or special characters\n" +
+                        "• Maximum length is 100 characters");
+    }
+    
+}

--- a/src/EnvironmentGateway/EnvironmentGateway.Domain/Clusters/Destinations/Destination.cs
+++ b/src/EnvironmentGateway/EnvironmentGateway.Domain/Clusters/Destinations/Destination.cs
@@ -17,7 +17,7 @@ public sealed class Destination : Entity
     }
 
     public Guid ClusterId { get; init; }
-    public Name DestinationName { get; init; } = new Name("null");
+    public Name DestinationName { get; private set; } = new Name("null");
     public Address Address { get; private set; } = new Address("null");
 
     public static Destination Create(string destinationName, string address)
@@ -34,5 +34,12 @@ public sealed class Destination : Entity
         ArgumentNullException.ThrowIfNull(address);
         
         Address = new Address(address);
+    }
+
+    public void ChangeName(string destinationName)
+    {
+        ArgumentNullException.ThrowIfNull(destinationName);
+        
+        DestinationName = new Name(destinationName);
     }
 }

--- a/src/admin-frontend/src/app/services/env-gateway/destination/destination.service.ts
+++ b/src/admin-frontend/src/app/services/env-gateway/destination/destination.service.ts
@@ -14,25 +14,23 @@ export class DestinationService {
   constructor() { }
 
   public SaveDestinationNameChanges(request: any): Promise<RequestResponse> {
-    return new Promise(resolve => {
-      setTimeout(() => resolve({ isError: false, message: 'Test: Destination name change simulated' }), 2000);
-    })
-    /*
-    return new Promise((resolve, reject) => {
-      this.httpClient.put(`https://localhost:9100/update-destination`, request, {
-
-      }).subscribe({
-        next: (response) => {
-          console.log('Destination updated successfully:', response);
-          resolve(`Destination updated successfully: ${JSON.stringify(response)}`);
-        },
-        error: (error) => {
-          console.error('Error updating destination:', error);
-          reject(`Error updating destination: ${JSON.stringify(error.message)}`);
-        }
-      });
+    return new Promise((resolve) => {
+      this.httpClient.put(`https://localhost:9100/change-destination-name`, request, {})
+        .subscribe({
+          next: (response) => {
+            console.log('Destination updated successfully:', response);
+            resolve({
+              isError: false,
+              message: 'Destination name was successfully changed.'
+            });
+          },
+          error: (error) => {
+            console.error('Error updating destination:', error);
+            const processedResponse = this.requestErrorHandler.handle(error.error);
+            resolve(processedResponse);
+          }
+        });
     });
-    */
   }
 
   public SaveDestinationAddressChanges(request: any): Promise<RequestResponse> {

--- a/src/admin-frontend/src/app/services/env-gateway/destination/destination.service.ts
+++ b/src/admin-frontend/src/app/services/env-gateway/destination/destination.service.ts
@@ -37,7 +37,7 @@ export class DestinationService {
 
   public SaveDestinationAddressChanges(request: any): Promise<RequestResponse> {
     return new Promise((resolve) => {
-      this.httpClient.put(`https://localhost:9100/update-destination`, request, {})
+      this.httpClient.put(`https://localhost:9100/change-destination-address`, request, {})
         .subscribe({
           next: (response) => {
             resolve({

--- a/tests/EnvironmentGateway/EnvironmentGateway.Api.FunctionalTests/Destinations/ChangeDestinationAddressTests.cs
+++ b/tests/EnvironmentGateway/EnvironmentGateway.Api.FunctionalTests/Destinations/ChangeDestinationAddressTests.cs
@@ -13,7 +13,7 @@ namespace EnvironmentGateway.Api.FunctionalTests.Destinations;
 public class ChangeDestinationAddressTests(FunctionalTestWebAppFactory factory) : BaseFunctionalTest(factory)
 {
     [Fact]
-    public async Task UpdateDestination_ShouldReturnOk_WhenRequestIsValid()
+    public async Task ChangeDestinationAddress_ShouldReturnOk_WhenRequestIsValid()
     {
         // Arrange
         var accessToken = await GetAccessTokenAsync();
@@ -32,7 +32,7 @@ public class ChangeDestinationAddressTests(FunctionalTestWebAppFactory factory) 
         var request = new ChangeDestinationAddressRequest(clusterId, destinationId, testAddress);
 
         // Act
-        HttpResponseMessage response = await HttpClient.PutAsJsonAsync("update-destination", request);
+        HttpResponseMessage response = await HttpClient.PutAsJsonAsync("change-destination-address", request);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -57,7 +57,7 @@ public class ChangeDestinationAddressTests(FunctionalTestWebAppFactory factory) 
     [InlineData("https://.com")]
     [InlineData("https://exam ple.com")]
     [InlineData("https://example!.com")]
-    public async Task UpdateDestination_ShouldReturnBadRequest_WhenDestinationAddressIsInvalid(string testAddress)
+    public async Task ChangeDestinationAddress_ShouldReturnBadRequest_WhenDestinationAddressIsInvalid(string testAddress)
     {
         // Arrange
         var accessToken = await GetAccessTokenAsync();
@@ -75,7 +75,7 @@ public class ChangeDestinationAddressTests(FunctionalTestWebAppFactory factory) 
         var request = new ChangeDestinationAddressRequest(clusterId, destinationId, testAddress);
 
         // Act
-        HttpResponseMessage response = await HttpClient.PutAsJsonAsync("update-destination", request);
+        HttpResponseMessage response = await HttpClient.PutAsJsonAsync("change-destination-address", request);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);

--- a/tests/EnvironmentGateway/EnvironmentGateway.Api.FunctionalTests/Destinations/ChangeDestinationAddressTests.cs
+++ b/tests/EnvironmentGateway/EnvironmentGateway.Api.FunctionalTests/Destinations/ChangeDestinationAddressTests.cs
@@ -3,7 +3,6 @@ using System.Net.Http.Json;
 using EnvironmentGateway.Api.Endpoints.Destinations.ChangeDestinationAddress;
 using EnvironmentGateway.Api.FunctionalTests.Infrastructure;
 using EnvironmentGateway.Domain.Clusters.Destinations;
-using EnvironmentGateway.Infrastructure;
 using FluentAssertions;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;

--- a/tests/EnvironmentGateway/EnvironmentGateway.Api.FunctionalTests/Destinations/ChangeDestinationNameTests.cs
+++ b/tests/EnvironmentGateway/EnvironmentGateway.Api.FunctionalTests/Destinations/ChangeDestinationNameTests.cs
@@ -3,7 +3,6 @@ using System.Net.Http.Json;
 using EnvironmentGateway.Api.Endpoints.Destinations.ChangeDestinationName;
 using EnvironmentGateway.Api.FunctionalTests.Infrastructure;
 using EnvironmentGateway.Domain.Clusters.Destinations;
-using EnvironmentGateway.Infrastructure;
 using FluentAssertions;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;

--- a/tests/EnvironmentGateway/EnvironmentGateway.Api.FunctionalTests/Destinations/ChangeDestinationNameTests.cs
+++ b/tests/EnvironmentGateway/EnvironmentGateway.Api.FunctionalTests/Destinations/ChangeDestinationNameTests.cs
@@ -1,0 +1,83 @@
+﻿using System.Net;
+using System.Net.Http.Json;
+using EnvironmentGateway.Api.Endpoints.Destinations.ChangeDestinationName;
+using EnvironmentGateway.Api.FunctionalTests.Infrastructure;
+using EnvironmentGateway.Domain.Clusters.Destinations;
+using EnvironmentGateway.Infrastructure;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.EntityFrameworkCore;
+
+namespace EnvironmentGateway.Api.FunctionalTests.Destinations;
+
+public class ChangeDestinationNameTests(FunctionalTestWebAppFactory factory) : BaseFunctionalTest(factory)
+{
+    [Fact]
+    public async Task UpdateDestinationName_ShouldReturnOk_WhenRequestIsValid()
+    {
+        // Arrange
+        var accessToken = await GetAccessTokenAsync();
+        HttpClient.DefaultRequestHeaders.Authorization =
+            new System.Net.Http.Headers.AuthenticationHeaderValue(
+                JwtBearerDefaults.AuthenticationScheme, accessToken);
+        const string testName = "NewDestinationName";
+        await CreateTestConfigAsync();
+        Guid clusterId = await DbContext.Clusters
+            .Select(c => c.Id)
+            .FirstOrDefaultAsync();
+        Guid destinationId = await DbContext.Clusters
+            .SelectMany(c => c.Destinations)
+            .Select(d => d.Id)
+            .FirstOrDefaultAsync();
+        var request = new ChangeDestinationNameRequest(clusterId, destinationId, testName);
+
+        // Act
+        HttpResponseMessage response = await HttpClient.PutAsJsonAsync("change-destination-name", request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        RenewDbContext();
+        var cluster = await DbContext.Clusters
+            .Include(c => c.Destinations)
+            .FirstOrDefaultAsync(c => c.Id == clusterId);
+        cluster.Should().NotBeNull();
+        Destination? updatedDestination = cluster.Destinations.FirstOrDefault(d => d.Id == destinationId);
+        updatedDestination.Should().NotBeNull();
+        updatedDestination.DestinationName.Value.Should().Be(testName);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("!")]
+    [InlineData("@invalid")]
+    [InlineData("NameWith#Hash")]
+    [InlineData("NameWith$Dollar")]
+    [InlineData("NameWith%Percent")]
+    [InlineData("NameWith^Caret")]
+    [InlineData("NameWith&And")]
+    [InlineData("NameWith*Star")]
+    public async Task UpdateDestinationName_ShouldReturnBadRequest_WhenDestinationNameIsInvalid(string testName)
+    {
+        // Arrange
+        var accessToken = await GetAccessTokenAsync();
+        HttpClient.DefaultRequestHeaders.Authorization =
+            new System.Net.Http.Headers.AuthenticationHeaderValue(
+                JwtBearerDefaults.AuthenticationScheme, accessToken);
+        await CreateTestConfigAsync();
+        Guid destinationId = await DbContext.Clusters
+            .SelectMany(c => c.Destinations)
+            .Select(d => d.Id)
+            .FirstOrDefaultAsync();
+        Guid clusterId = await DbContext.Clusters
+            .Select(c => c.Id)
+            .FirstOrDefaultAsync();
+        var request = new ChangeDestinationNameRequest(clusterId, destinationId, testName);
+
+        // Act
+        HttpResponseMessage response = await HttpClient.PutAsJsonAsync("change-destination-name", request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+}

--- a/tests/EnvironmentGateway/EnvironmentGateway.Application.IntegrationTests/Destinations/ChangeDestinationAddressTests.cs
+++ b/tests/EnvironmentGateway/EnvironmentGateway.Application.IntegrationTests/Destinations/ChangeDestinationAddressTests.cs
@@ -1,5 +1,5 @@
 ﻿using EnvironmentGateway.Application.Abstractions.Messaging;
-using EnvironmentGateway.Application.Destinations.UpdateDestination;
+using EnvironmentGateway.Application.Destinations.ChangeDestinationAddress;
 using EnvironmentGateway.Application.IntegrationTests.Infrastructure;
 using EnvironmentGateway.Domain.Abstractions;
 using EnvironmentGateway.Domain.Clusters.Destinations;

--- a/tests/EnvironmentGateway/EnvironmentGateway.Application.IntegrationTests/Destinations/ChangeDestinationNameTests.cs
+++ b/tests/EnvironmentGateway/EnvironmentGateway.Application.IntegrationTests/Destinations/ChangeDestinationNameTests.cs
@@ -1,0 +1,80 @@
+﻿using EnvironmentGateway.Application.Abstractions.Messaging;
+using EnvironmentGateway.Application.Destinations.ChangeDestinationName;
+using EnvironmentGateway.Application.IntegrationTests.Infrastructure;
+using EnvironmentGateway.Domain.Abstractions;
+using EnvironmentGateway.Domain.Clusters.Destinations;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EnvironmentGateway.Application.IntegrationTests.Destinations;
+
+public class ChangeDestinationNameTests : BaseIntegrationTest
+{
+    private readonly ICommandHandler<ChangeDestinationNameCommand> _handler;
+    private const string TestName = "TestDestinationName";
+
+    public ChangeDestinationNameTests(IntegrationTestWebAppFactory factory)
+        : base(factory)
+    {
+        _handler = Scope.ServiceProvider.GetRequiredService<ICommandHandler<ChangeDestinationNameCommand>>();
+    }
+
+    [Fact]
+    public async Task ChangeDestinationName_ShouldReturnSuccess_WhenDestinationNameWasChanged()
+    {
+        // Arrange
+        Guid destinationId = await DbContext.Clusters
+            .SelectMany(c => c.Destinations)
+            .Select(d => d.Id)
+            .FirstOrDefaultAsync();
+        Guid clusterId = await DbContext.Clusters
+            .Select(c => c.Id)
+            .FirstOrDefaultAsync();
+        var request = new ChangeDestinationNameCommand(clusterId, destinationId, TestName);
+
+        // Act
+        Result result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        var cluster = await DbContext.Clusters
+            .Include(c => c.Destinations)
+            .FirstOrDefaultAsync(c => c.Id == clusterId);
+        cluster.Should().NotBeNull();
+        Destination? updatedDestination = cluster!.Destinations.FirstOrDefault(d => d.Id == destinationId);
+        updatedDestination.Should().NotBeNull();
+        updatedDestination.DestinationName.Value.Should().Be(TestName);
+    }
+
+    [Fact]
+    public async Task ChangeDestinationName_ShouldReturnFailure_WhenDestinationDoesNotExist()
+    {
+        // Arrange
+        var request = new ChangeDestinationNameCommand(Guid.NewGuid(), Guid.NewGuid(), TestName);
+
+        // Act
+        Result result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task ChangeDestinationName_ShouldReturnFailure_WhenClusterDoesNotExist()
+    {
+        // Arrange
+        Guid destinationId = await DbContext.Clusters
+            .SelectMany(c => c.Destinations)
+            .Select(d => d.Id)
+            .FirstOrDefaultAsync();
+        var request = new ChangeDestinationNameCommand(Guid.NewGuid(), destinationId, TestName);
+
+        // Act
+        Result result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+    }
+}

--- a/tests/EnvironmentGateway/EnvironmentGateway.Application.UnitTests/Destinations/ChangeDestinationAddressTests.cs
+++ b/tests/EnvironmentGateway/EnvironmentGateway.Application.UnitTests/Destinations/ChangeDestinationAddressTests.cs
@@ -1,4 +1,4 @@
-﻿using EnvironmentGateway.Application.Destinations.UpdateDestination;
+﻿using EnvironmentGateway.Application.Destinations.ChangeDestinationAddress;
 using EnvironmentGateway.Domain.Abstractions;
 using EnvironmentGateway.Domain.Clusters;
 using EnvironmentGateway.Domain.Clusters.Destinations;

--- a/tests/EnvironmentGateway/EnvironmentGateway.Application.UnitTests/Destinations/ChangeDestinationNameTests.cs
+++ b/tests/EnvironmentGateway/EnvironmentGateway.Application.UnitTests/Destinations/ChangeDestinationNameTests.cs
@@ -1,0 +1,130 @@
+﻿using EnvironmentGateway.Application.Destinations.ChangeDestinationName;
+using EnvironmentGateway.Domain.Abstractions;
+using EnvironmentGateway.Domain.Clusters;
+using EnvironmentGateway.Domain.Clusters.Destinations;
+using FluentAssertions;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+namespace EnvironmentGateway.Application.UnitTests.Destinations;
+
+public class ChangeDestinationNameTests
+{
+    private static readonly Guid ClusterId = Guid.NewGuid();
+    private static readonly Guid DestinationId = Guid.NewGuid();
+    private const string TestDestinationName = "TestDestination";
+    private const string TestClusterName = "TestCluster";
+    private const string TestAddress = "Https://test-address.com";
+    private const string NewDestinationName = "NewDestinationName";
+
+    private static readonly ChangeDestinationNameCommand NameCommand = new(
+        ClusterId,
+        DestinationId,
+        NewDestinationName);
+
+    private readonly ChangeDestinationNameCommandHandler _handler;
+    private readonly IDestinationRepository _destinationRepositoryMock;
+    private readonly IUnitOfWork _unitOfWorkMock;
+
+    public ChangeDestinationNameTests()
+    {
+        _destinationRepositoryMock = Substitute.For<IDestinationRepository>();
+        _unitOfWorkMock = Substitute.For<IUnitOfWork>();
+
+        _handler = new ChangeDestinationNameCommandHandler(
+            _destinationRepositoryMock,
+            _unitOfWorkMock);
+    }
+
+    [Fact]
+    public async Task Handle_Should_ReturnFailure_WhenDestinationDoesNotExist()
+    {
+        // Arrange
+        _destinationRepositoryMock.GetByIdAsync(
+            ClusterId,
+            DestinationId,
+            Arg.Any<CancellationToken>()).Returns((Destination?)null);
+
+        // Act
+        var result = await _handler.Handle(NameCommand, default);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be(DestinationErrors.NotFound);
+    }
+
+    [Fact]
+    public async Task Handle_Should_ReturnFailure_WhenUnitOfWorkThrowsException()
+    {
+        // Arrange
+        var cluster = Cluster.Create(TestClusterName, TestDestinationName, TestAddress);
+        _destinationRepositoryMock.GetByIdAsync(
+            ClusterId,
+            DestinationId,
+            Arg.Any<CancellationToken>()).Returns(cluster.Destinations[0]);
+        _unitOfWorkMock.SaveChangesAsync(
+            Arg.Any<CancellationToken>()).Throws(new Exception());
+
+        // Act & Assert
+        await FluentActions.Invoking(() => _handler.Handle(NameCommand, default))
+            .Should().ThrowAsync<Exception>();
+    }
+
+    [Fact]
+    public async Task Handle_Should_UpdateDestinationName_WhenDestinationExists()
+    {
+        // Arrange
+        var cluster = Cluster.Create(TestClusterName, TestDestinationName, TestAddress);
+        _destinationRepositoryMock.GetByIdAsync(
+            ClusterId,
+            DestinationId,
+            Arg.Any<CancellationToken>()).Returns(cluster.Destinations[0]);
+
+        // Act
+        var result = await _handler.Handle(NameCommand, default);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        await _destinationRepositoryMock.Received(1).GetByIdAsync(ClusterId, DestinationId, Arg.Any<CancellationToken>());
+        await _unitOfWorkMock.Received(1).SaveChangesAsync(Arg.Any<CancellationToken>());
+        cluster.Destinations[0].DestinationName.Value.Should().Be(NewDestinationName);
+    }
+
+    [Fact]
+    public async Task Handle_Should_NotCallSaveChanges_WhenDestinationDoesNotExist()
+    {
+        // Arrange
+        _destinationRepositoryMock.GetByIdAsync(
+            ClusterId,
+            DestinationId,
+            Arg.Any<CancellationToken>()).Returns((Destination?)null);
+
+        // Act
+        var result = await _handler.Handle(NameCommand, default);
+
+        // Assert
+        await _unitOfWorkMock.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+        result.IsFailure.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Handle_Should_PropagateCancellationToken()
+    {
+        // Arrange
+        var cluster = Cluster.Create(TestClusterName, TestDestinationName, TestAddress);
+        _destinationRepositoryMock.GetByIdAsync(
+            ClusterId,
+            DestinationId,
+            Arg.Any<CancellationToken>()).Returns(cluster.Destinations[0]);
+
+        using var cts = new CancellationTokenSource();
+        var token = cts.Token;
+
+        // Act
+        await _handler.Handle(NameCommand, token);
+
+        // Assert
+        await _destinationRepositoryMock.Received(1).GetByIdAsync(ClusterId, DestinationId, token);
+        await _unitOfWorkMock.Received(1).SaveChangesAsync(token);
+    }
+}

--- a/tests/EnvironmentGateway/EnvironmentGateway.ArchitectureTests/Application/ApplicationTests.cs
+++ b/tests/EnvironmentGateway/EnvironmentGateway.ArchitectureTests/Application/ApplicationTests.cs
@@ -96,4 +96,17 @@ public class ApplicationTests : BaseTest
 
         result.IsSuccessful.Should().BeTrue();
     }
+    
+    [Fact]
+    public void Validator_Should_BeSealed()
+    {
+        var result = Types.InAssembly(ApplicationAssembly)
+            .That()
+            .Inherit(typeof(FluentValidation.AbstractValidator<>))
+            .Should()
+            .BeSealed()
+            .GetResult();
+
+        result.IsSuccessful.Should().BeTrue();
+    }
 }

--- a/tests/EnvironmentGateway/EnvironmentGateway.ArchitectureTests/Application/ApplicationTests.cs
+++ b/tests/EnvironmentGateway/EnvironmentGateway.ArchitectureTests/Application/ApplicationTests.cs
@@ -71,5 +71,29 @@ public class ApplicationTests : BaseTest
         result.IsSuccessful.Should().BeTrue();
     }
 
-    // todo: Validator tests, naming convention and access modifier!
+    [Fact]
+    public void Validator_ShouldHave_NameEndingWith_Validator()
+    {
+        var result = Types.InAssembly(ApplicationAssembly)
+            .That()
+            .Inherit(typeof(FluentValidation.AbstractValidator<>))
+            .Should()
+            .HaveNameEndingWith("Validator")
+            .GetResult();
+
+        result.IsSuccessful.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validator_Should_NotBePublic()
+    {
+        var result = Types.InAssembly(ApplicationAssembly)
+            .That()
+            .Inherit(typeof(FluentValidation.AbstractValidator<>))
+            .Should()
+            .NotBePublic()
+            .GetResult();
+
+        result.IsSuccessful.Should().BeTrue();
+    }
 }

--- a/tests/EnvironmentGateway/EnvironmentGateway.Domain.UnitTests/Clusters/Destinations/DestinationsTests.cs
+++ b/tests/EnvironmentGateway/EnvironmentGateway.Domain.UnitTests/Clusters/Destinations/DestinationsTests.cs
@@ -8,6 +8,7 @@ public class DestinationsTests
     private const string TestName = "TestName";
     private const string TestAddress = "https://test-address.com";
     private const string NewAddress = "https://new-address.com";
+    private const string NewName = "NewName";
 
     [Fact]
     public void CreateNewDestination_Should_SetPropertyValues()
@@ -53,6 +54,32 @@ public class DestinationsTests
 
         // Act
         Action act = () => destination.ChangeAddress(null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void ChangeName_Should_ChangeDestinationName()
+    {
+        // Arrange
+        var destination = Destination.Create(TestName, TestAddress);
+
+        // Act
+        destination.ChangeName(NewName);
+
+        // Assert
+        destination.DestinationName.Value.Should().Be(NewName);
+    }
+
+    [Fact]
+    public void ChangeName_Should_ThrowArgumentNullException_When_NameIsNull()
+    {
+        // Arrange
+        var destination = Destination.Create(TestName, TestAddress);
+
+        // Act
+        Action act = () => destination.ChangeName(null!);
 
         // Assert
         act.Should().Throw<ArgumentNullException>();


### PR DESCRIPTION
This pull request refactors the destination update endpoints to improve clarity and adds full support for changing a destination's name, including backend, validation, and frontend integration. The changes also update tests and internal naming to match the new endpoints.

**API Endpoint Refactoring and Feature Addition**

* Changed the endpoint for updating a destination's address from `update-destination` to `change-destination-address` throughout the backend and tests, including renaming related classes and namespaces for consistency. [[1]](diffhunk://#diff-811608a262b4a8799e26ae4c374ff0e9564dda2201755f8e4a012339096b5bf9L3-R23) [[2]](diffhunk://#diff-811608a262b4a8799e26ae4c374ff0e9564dda2201755f8e4a012339096b5bf9L33-R34) [[3]](diffhunk://#diff-097f10c8ff183bc68b1750c5079a2f3b66d16908d53d71fb47692ac824b9d940L1-R4) [[4]](diffhunk://#diff-08fee28788e46906297efd737900efe0316f976ffa9a90f139ec4563083f942dL5-R5) [[5]](diffhunk://#diff-cce2601f7c5661ae656f1aa13f8c418a02a108d4f40258d8de960a8312bd30caL1-R6) [[6]](diffhunk://#diff-6195ed6863d70e5df7522cd135d529be2168ab6b76212b0bef9b8410c8ccfbacL3) [[7]](diffhunk://#diff-6f709666943c29c0129777c94681c70e10adff250b6e9fb5ea77fd7d7e235832L2-R2) [[8]](diffhunk://#diff-505e742576c1aa0aea3a1da5f0ab606e00b8c26eb7bc6b869e4479f1e5940419L16-R16) [[9]](diffhunk://#diff-505e742576c1aa0aea3a1da5f0ab606e00b8c26eb7bc6b869e4479f1e5940419L35-R35) [[10]](diffhunk://#diff-505e742576c1aa0aea3a1da5f0ab606e00b8c26eb7bc6b869e4479f1e5940419L60-R60) [[11]](diffhunk://#diff-505e742576c1aa0aea3a1da5f0ab606e00b8c26eb7bc6b869e4479f1e5940419L78-R78)
* Added a new endpoint `change-destination-name` with corresponding request and command handler classes, enabling the ability to change a destination's name via API. [[1]](diffhunk://#diff-0ca67b2826cd4cb03eb295f6f7504d6ec524ee38237abb0841728e42082ac2d7R1-R38) [[2]](diffhunk://#diff-94fb4ac38d20449f3e9bcaba2e201443c9714cd797fee5741a6bfe9f03660b01R1-R8) [[3]](diffhunk://#diff-9bb18c06164fb55f5f7692e0460b970b408b4f80e6e208082659d9f1814a19ebR1-R9) [[4]](diffhunk://#diff-518c0a1d1c08a3519c190310035435bc5d595bfad661e445b2b772b65b166f62R1-R30)

**Validation Improvements**

* Implemented a new validator `ChangeDestinationNameValidator` to enforce rules for destination names: only letters, numbers, and `-` allowed, no spaces or special characters, max length 100.

**Domain Model Enhancements**

* Added a `ChangeName` method to the `Destination` domain model and made the `DestinationName` property mutable to support name changes. [[1]](diffhunk://#diff-10c579d0c54c4b5c2a088fededa15fdd4879a63b7a71dea56808ec6f531e1e1bL20-R20) [[2]](diffhunk://#diff-10c579d0c54c4b5c2a088fededa15fdd4879a63b7a71dea56808ec6f531e1e1bR38-R44)

**Frontend Integration**

* Updated the frontend service to use the new endpoints for changing destination name and address, and improved response handling for both success and error cases.

**Test Coverage**

* Added comprehensive functional tests for the new `change-destination-name` endpoint, including validation for both valid and invalid names.