### PR TITLE
77 feature backend implement functionality to change cluster name

### DIFF
--- a/src/EnvironmentGateway/EnvironmentGateway.Api/Endpoints/Clusters/ChangeClusterName/ChangeClusterName.cs
+++ b/src/EnvironmentGateway/EnvironmentGateway.Api/Endpoints/Clusters/ChangeClusterName/ChangeClusterName.cs
@@ -1,0 +1,36 @@
+﻿using EnvironmentGateway.Api.GatewayConfiguration.Abstractions;
+using EnvironmentGateway.Application.Abstractions.Messaging;
+using EnvironmentGateway.Application.Clusters.ChangeClusterName;
+using EnvironmentGateway.Domain.Abstractions;
+
+namespace EnvironmentGateway.Api.Endpoints.Clusters.ChangeClusterName;
+
+public class ChangeClusterName : IEndpoint
+{
+    public void MapEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapPut("change-cluster-name",
+                async (
+                    ChangeClusterNameRequest request,
+                    ICommandHandler<ChangeClusterNameCommand> commandHandler,
+                    IRuntimeConfigurator runtimeConfigurator,
+                    CancellationToken cancellationToken) =>
+                {
+                    var command = new ChangeClusterNameCommand(
+                        request.ClusterId,
+                        request.ClusterName);
+                    
+                    var result = await commandHandler.Handle(command, cancellationToken);
+
+                    if (result.IsFailure)
+                    {
+                        return Results.BadRequest(result.Error);
+                    }
+                    
+                    var updateResult = await runtimeConfigurator.UpdateProxyConfig();
+
+                    return Results.Ok(updateResult.IsSuccess);
+                }
+            );
+    }
+}

--- a/src/EnvironmentGateway/EnvironmentGateway.Api/Endpoints/Clusters/ChangeClusterName/ChangeClusterName.cs
+++ b/src/EnvironmentGateway/EnvironmentGateway.Api/Endpoints/Clusters/ChangeClusterName/ChangeClusterName.cs
@@ -31,6 +31,7 @@ public class ChangeClusterName : IEndpoint
 
                     return Results.Ok(updateResult.IsSuccess);
                 }
-            );
+            )
+            .RequireAuthorization();
     }
 }

--- a/src/EnvironmentGateway/EnvironmentGateway.Api/Endpoints/Clusters/ChangeClusterName/ChangeClusterNameRequest.cs
+++ b/src/EnvironmentGateway/EnvironmentGateway.Api/Endpoints/Clusters/ChangeClusterName/ChangeClusterNameRequest.cs
@@ -1,0 +1,5 @@
+﻿namespace EnvironmentGateway.Api.Endpoints.Clusters.ChangeClusterName;
+
+public sealed record ChangeClusterNameRequest(
+    Guid ClusterId,
+    string ClusterName);

--- a/src/EnvironmentGateway/EnvironmentGateway.Application/Clusters/ChangeClusterName/ChangeClusterNameCommand.cs
+++ b/src/EnvironmentGateway/EnvironmentGateway.Application/Clusters/ChangeClusterName/ChangeClusterNameCommand.cs
@@ -1,0 +1,8 @@
+﻿using EnvironmentGateway.Application.Abstractions.Messaging;
+
+namespace EnvironmentGateway.Application.Clusters.ChangeClusterName;
+
+public sealed record ChangeClusterNameCommand(
+    Guid ClusterId,
+    string ClusterName)
+    : ICommand;

--- a/src/EnvironmentGateway/EnvironmentGateway.Application/Clusters/ChangeClusterName/ChangeClusterNameCommandHandler.cs
+++ b/src/EnvironmentGateway/EnvironmentGateway.Application/Clusters/ChangeClusterName/ChangeClusterNameCommandHandler.cs
@@ -5,7 +5,7 @@ using EnvironmentGateway.Domain.Clusters;
 namespace EnvironmentGateway.Application.Clusters.ChangeClusterName;
 
 internal sealed class ChangeClusterNameCommandHandler(
-    IClusterRepository clusterReppository,
+    IClusterRepository clusterRepository,
     IUnitOfWork unitOfWork)
     : ICommandHandler<ChangeClusterNameCommand>
 {
@@ -13,7 +13,7 @@ internal sealed class ChangeClusterNameCommandHandler(
         ChangeClusterNameCommand command, 
         CancellationToken cancellationToken)
     {
-        var cluster = await clusterReppository
+        var cluster = await clusterRepository
             .GetByIdAsync(command.ClusterId, cancellationToken);
 
         if (cluster is null)

--- a/src/EnvironmentGateway/EnvironmentGateway.Application/Clusters/ChangeClusterName/ChangeClusterNameCommandHandler.cs
+++ b/src/EnvironmentGateway/EnvironmentGateway.Application/Clusters/ChangeClusterName/ChangeClusterNameCommandHandler.cs
@@ -22,6 +22,8 @@ internal sealed class ChangeClusterNameCommandHandler(
         }
 
         cluster.ChangeName(command.ClusterName);
+
+        await unitOfWork.SaveChangesAsync(cancellationToken);
         
         return Result.Success();
     }

--- a/src/EnvironmentGateway/EnvironmentGateway.Application/Clusters/ChangeClusterName/ChangeClusterNameCommandHandler.cs
+++ b/src/EnvironmentGateway/EnvironmentGateway.Application/Clusters/ChangeClusterName/ChangeClusterNameCommandHandler.cs
@@ -1,0 +1,16 @@
+﻿using EnvironmentGateway.Application.Abstractions.Messaging;
+using EnvironmentGateway.Domain.Abstractions;
+using EnvironmentGateway.Domain.Clusters;
+
+namespace EnvironmentGateway.Application.Clusters.ChangeClusterName;
+
+internal sealed class ChangeClusterNameCommandHandler(
+    IClusterRepository clusterReppository,
+    IUnitOfWork unitOfWork)
+    : ICommandHandler<ChangeClusterNameCommand>
+{
+    public Task<Result> Handle(ChangeClusterNameCommand command, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/EnvironmentGateway/EnvironmentGateway.Application/Clusters/ChangeClusterName/ChangeClusterNameCommandHandler.cs
+++ b/src/EnvironmentGateway/EnvironmentGateway.Application/Clusters/ChangeClusterName/ChangeClusterNameCommandHandler.cs
@@ -9,8 +9,20 @@ internal sealed class ChangeClusterNameCommandHandler(
     IUnitOfWork unitOfWork)
     : ICommandHandler<ChangeClusterNameCommand>
 {
-    public Task<Result> Handle(ChangeClusterNameCommand command, CancellationToken cancellationToken)
+    public async Task<Result> Handle(
+        ChangeClusterNameCommand command, 
+        CancellationToken cancellationToken)
     {
-        throw new NotImplementedException();
+        var cluster = await clusterReppository
+            .GetByIdAsync(command.ClusterId, cancellationToken);
+
+        if (cluster is null)
+        {
+            return Result.Failure(ClusterErrors.NotFound);
+        }
+
+        cluster.ChangeName(command.ClusterName);
+        
+        return Result.Success();
     }
 }

--- a/src/EnvironmentGateway/EnvironmentGateway.Application/Clusters/ChangeClusterName/ChangeClusterNameValidator.cs
+++ b/src/EnvironmentGateway/EnvironmentGateway.Application/Clusters/ChangeClusterName/ChangeClusterNameValidator.cs
@@ -1,0 +1,22 @@
+﻿using System.Text.RegularExpressions;
+using FluentValidation;
+
+namespace EnvironmentGateway.Application.Clusters.ChangeClusterName;
+
+internal sealed class ChangeClusterNameValidator : AbstractValidator<ChangeClusterNameCommand>
+{
+    private const string UrlPattern = "^[A-Za-z0-9-]+$";
+    
+    public ChangeClusterNameValidator()
+    {
+        RuleFor(x => x.ClusterName)
+            .NotEmpty()
+            .MaximumLength(100)
+            .Matches(UrlPattern, RegexOptions.IgnoreCase)
+            .WithMessage("Please enter a valid name for the cluster.\n" +
+                         "Please make sure to follow these rules:\n" +
+                         "• The name may only contain letters, numbers, and the '-' character\n" +
+                         "• Do not use spaces or special characters\n" +
+                         "• Maximum length is 100 characters");
+    }
+}

--- a/src/EnvironmentGateway/EnvironmentGateway.Domain/Clusters/Cluster.cs
+++ b/src/EnvironmentGateway/EnvironmentGateway.Domain/Clusters/Cluster.cs
@@ -19,7 +19,7 @@ public sealed class Cluster : Entity
 
     public Guid GatewayConfigId { get; init; }
     public GatewayConfig GatewayConfig { get; init; } = null!;
-    public Name ClusterName { get; init; } = new Name("cluster1");
+    public Name ClusterName { get; private set; } = new Name("cluster1");
     public List<Destination> Destinations { get; } = [];
 
     public static Cluster Create(
@@ -43,5 +43,12 @@ public sealed class Cluster : Entity
         ArgumentNullException.ThrowIfNull(destination);
         
         Destinations.Add(destination);
+    }
+
+    public void ChangeName(string clusterName)
+    {
+        ArgumentNullException.ThrowIfNull(clusterName);
+        
+        ClusterName = new Name(clusterName);
     }
 }

--- a/src/EnvironmentGateway/EnvironmentGateway.Domain/Clusters/ClusterErrors.cs
+++ b/src/EnvironmentGateway/EnvironmentGateway.Domain/Clusters/ClusterErrors.cs
@@ -1,0 +1,10 @@
+﻿using EnvironmentGateway.Domain.Abstractions;
+
+namespace EnvironmentGateway.Domain.Clusters;
+
+public static class ClusterErrors
+{
+    public static readonly Error NotFound = new(
+        "Cluster.NotFound",
+        "The cluster with the specified identifier was not found");
+}

--- a/src/EnvironmentGateway/EnvironmentGateway.Domain/Clusters/IClusterRepository.cs
+++ b/src/EnvironmentGateway/EnvironmentGateway.Domain/Clusters/IClusterRepository.cs
@@ -1,0 +1,8 @@
+﻿namespace EnvironmentGateway.Domain.Clusters;
+
+public interface IClusterRepository
+{
+    Task<Cluster?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
+
+    void Add(Cluster cluster);
+}

--- a/src/EnvironmentGateway/EnvironmentGateway.Infrastructure/DependencyInjection.cs
+++ b/src/EnvironmentGateway/EnvironmentGateway.Infrastructure/DependencyInjection.cs
@@ -1,6 +1,7 @@
 ﻿using EnvironmentGateway.Application.Abstractions.Data;
 using EnvironmentGateway.Application.Abstractions.Email;
 using EnvironmentGateway.Domain.Abstractions;
+using EnvironmentGateway.Domain.Clusters;
 using EnvironmentGateway.Domain.Clusters.Destinations;
 using EnvironmentGateway.Domain.GatewayConfigs;
 using EnvironmentGateway.Infrastructure.Authentication;
@@ -50,6 +51,8 @@ public static class DependencyInjection
         });
 
         services.AddScoped<IGatewayConfigRepository, GatewayConfigRepository>();
+
+        services.AddScoped<IClusterRepository, ClusterRepository>();
         
         services.AddScoped<IDestinationRepository, DestinationRepository>();
 

--- a/src/EnvironmentGateway/EnvironmentGateway.Infrastructure/Repositories/ClusterRepository.cs
+++ b/src/EnvironmentGateway/EnvironmentGateway.Infrastructure/Repositories/ClusterRepository.cs
@@ -1,0 +1,10 @@
+﻿using EnvironmentGateway.Domain.Clusters;
+
+namespace EnvironmentGateway.Infrastructure.Repositories;
+
+internal sealed class ClusterRepository(
+    EnvironmentGatewayDbContext dbContext)
+    : Repository<Cluster>(dbContext), IClusterRepository
+{
+    
+}

--- a/tests/EnvironmentGateway/EnvironmentGateway.Api.FunctionalTests/Clusters/ChangeClusterNameTests.cs
+++ b/tests/EnvironmentGateway/EnvironmentGateway.Api.FunctionalTests/Clusters/ChangeClusterNameTests.cs
@@ -1,0 +1,70 @@
+﻿using System.Net;
+using System.Net.Http.Json;
+using EnvironmentGateway.Api.Endpoints.Clusters.ChangeClusterName;
+using EnvironmentGateway.Api.FunctionalTests.Infrastructure;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.EntityFrameworkCore;
+
+namespace EnvironmentGateway.Api.FunctionalTests.Clusters;
+
+public class ChangeClusterNameTests(FunctionalTestWebAppFactory factory) : BaseFunctionalTest(factory)
+{
+    [Fact]
+    public async Task ChangeClusterName_ShouldReturnOk_WhenRequestIsValid()
+    {
+        // Arrange
+        var accessToken = await GetAccessTokenAsync();
+        HttpClient.DefaultRequestHeaders.Authorization =
+            new System.Net.Http.Headers.AuthenticationHeaderValue(
+                JwtBearerDefaults.AuthenticationScheme, accessToken);
+        const string testName = "NewClusterName";
+        await CreateTestConfigAsync();
+        Guid clusterId = await DbContext.Clusters
+            .Select(c => c.Id)
+            .FirstOrDefaultAsync();
+        var request = new ChangeClusterNameRequest(clusterId, testName);
+
+        // Act
+        HttpResponseMessage response = await HttpClient.PutAsJsonAsync("change-cluster-name", request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        RenewDbContext();
+        var cluster = await DbContext.Clusters
+            .FirstOrDefaultAsync(c => c.Id == clusterId);
+        cluster.Should().NotBeNull();
+        cluster!.ClusterName.Value.Should().Be(testName);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("!")]
+    [InlineData("@invalid")]
+    [InlineData("NameWith#Hash")]
+    [InlineData("NameWith$Dollar")]
+    [InlineData("NameWith%Percent")]
+    [InlineData("NameWith^Caret")]
+    [InlineData("NameWith&And")]
+    [InlineData("NameWith*Star")]
+    public async Task ChangeClusterName_ShouldReturnBadRequest_WhenClusterNameIsInvalid(string testName)
+    {
+        // Arrange
+        var accessToken = await GetAccessTokenAsync();
+        HttpClient.DefaultRequestHeaders.Authorization =
+            new System.Net.Http.Headers.AuthenticationHeaderValue(
+                JwtBearerDefaults.AuthenticationScheme, accessToken);
+        await CreateTestConfigAsync();
+        Guid clusterId = await DbContext.Clusters
+            .Select(c => c.Id)
+            .FirstOrDefaultAsync();
+        var request = new ChangeClusterNameRequest(clusterId, testName);
+
+        // Act
+        HttpResponseMessage response = await HttpClient.PutAsJsonAsync("change-cluster-name", request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+}

--- a/tests/EnvironmentGateway/EnvironmentGateway.Application.IntegrationTests/Clusters/ChangeClusterNameTests.cs
+++ b/tests/EnvironmentGateway/EnvironmentGateway.Application.IntegrationTests/Clusters/ChangeClusterNameTests.cs
@@ -1,0 +1,56 @@
+﻿using EnvironmentGateway.Application.Abstractions.Messaging;
+using EnvironmentGateway.Application.Clusters.ChangeClusterName;
+using EnvironmentGateway.Application.IntegrationTests.Infrastructure;
+using EnvironmentGateway.Domain.Abstractions;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EnvironmentGateway.Application.IntegrationTests.Clusters;
+
+public class ChangeClusterNameTests : BaseIntegrationTest
+{
+    private readonly ICommandHandler<ChangeClusterNameCommand> _handler;
+    private const string TestName = "TestClusterName";
+
+    public ChangeClusterNameTests(IntegrationTestWebAppFactory factory)
+        : base(factory)
+    {
+        _handler = Scope.ServiceProvider.GetRequiredService<ICommandHandler<ChangeClusterNameCommand>>();
+    }
+
+    [Fact]
+    public async Task ChangeClusterName_ShouldReturnSuccess_WhenClusterNameWasChanged()
+    {
+        // Arrange
+        Guid clusterId = await DbContext.Clusters
+            .Select(c => c.Id)
+            .FirstOrDefaultAsync();
+        var request = new ChangeClusterNameCommand(clusterId, TestName);
+
+        // Act
+        Result result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+
+        var cluster = await DbContext.Clusters
+            .FirstOrDefaultAsync(c => c.Id == clusterId);
+        cluster.Should().NotBeNull();
+        cluster!.ClusterName.Value.Should().Be(TestName);
+    }
+
+    [Fact]
+    public async Task ChangeClusterName_ShouldReturnFailure_WhenClusterDoesNotExist()
+    {
+        // Arrange
+        var request = new ChangeClusterNameCommand(Guid.NewGuid(), TestName);
+
+        // Act
+        Result result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().NotBeNull();
+    }
+}

--- a/tests/EnvironmentGateway/EnvironmentGateway.Application.UnitTests/ChangeClusterNameTests.cs
+++ b/tests/EnvironmentGateway/EnvironmentGateway.Application.UnitTests/ChangeClusterNameTests.cs
@@ -1,0 +1,122 @@
+﻿using EnvironmentGateway.Application.Clusters.ChangeClusterName;
+using EnvironmentGateway.Domain.Abstractions;
+using EnvironmentGateway.Domain.Clusters;
+using FluentAssertions;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+namespace EnvironmentGateway.Application.UnitTests;
+
+public class ChangeClusterNameTests
+{
+    private static readonly Guid ClusterId = Guid.NewGuid();
+    private const string TestClusterName = "TestCluster";
+    private const string TestDestinationName = "TestDestination";
+    private const string TestAddress = "https://test-address.com";
+    private const string NewClusterName = "NewClusterName";
+
+    private static readonly ChangeClusterNameCommand NameCommand = new(
+        ClusterId,
+        NewClusterName);
+
+    private readonly ChangeClusterNameCommandHandler _handler;
+    private readonly IClusterRepository _clusterRepositoryMock;
+    private readonly IUnitOfWork _unitOfWorkMock;
+
+    public ChangeClusterNameTests()
+    {
+        _clusterRepositoryMock = Substitute.For<IClusterRepository>();
+        _unitOfWorkMock = Substitute.For<IUnitOfWork>();
+
+        _handler = new ChangeClusterNameCommandHandler(
+            _clusterRepositoryMock,
+            _unitOfWorkMock);
+    }
+
+    [Fact]
+    public async Task Handle_Should_ReturnFailure_WhenClusterDoesNotExist()
+    {
+        // Arrange
+        _clusterRepositoryMock.GetByIdAsync(
+            ClusterId,
+            Arg.Any<CancellationToken>()).Returns((Cluster?)null);
+
+        // Act
+        var result = await _handler.Handle(NameCommand, default);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be(ClusterErrors.NotFound);
+    }
+
+    [Fact]
+    public async Task Handle_Should_ReturnFailure_WhenUnitOfWorkThrowsException()
+    {
+        // Arrange
+        var cluster = Cluster.Create(TestClusterName, TestDestinationName, TestAddress);
+        _clusterRepositoryMock.GetByIdAsync(
+            ClusterId,
+            Arg.Any<CancellationToken>()).Returns(cluster);
+        _unitOfWorkMock.SaveChangesAsync(
+            Arg.Any<CancellationToken>()).Throws(new Exception());
+
+        // Act & Assert
+        await FluentActions.Invoking(() => _handler.Handle(NameCommand, default))
+            .Should().ThrowAsync<Exception>();
+    }
+
+    [Fact]
+    public async Task Handle_Should_UpdateClusterName_WhenClusterExists()
+    {
+        // Arrange
+        var cluster = Cluster.Create(TestClusterName, TestDestinationName, TestAddress);
+        _clusterRepositoryMock.GetByIdAsync(
+            ClusterId,
+            Arg.Any<CancellationToken>()).Returns(cluster);
+
+        // Act
+        var result = await _handler.Handle(NameCommand, default);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        await _clusterRepositoryMock.Received(1).GetByIdAsync(ClusterId, Arg.Any<CancellationToken>());
+        await _unitOfWorkMock.Received(1).SaveChangesAsync(Arg.Any<CancellationToken>());
+        cluster.ClusterName.Value.Should().Be(NewClusterName);
+    }
+
+    [Fact]
+    public async Task Handle_Should_NotCallSaveChanges_WhenClusterDoesNotExist()
+    {
+        // Arrange
+        _clusterRepositoryMock.GetByIdAsync(
+            ClusterId,
+            Arg.Any<CancellationToken>()).Returns((Cluster?)null);
+
+        // Act
+        var result = await _handler.Handle(NameCommand, default);
+
+        // Assert
+        await _unitOfWorkMock.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+        result.IsFailure.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Handle_Should_PropagateCancellationToken()
+    {
+        // Arrange
+        var cluster = Cluster.Create(TestClusterName, TestDestinationName, TestAddress);
+        _clusterRepositoryMock.GetByIdAsync(
+            ClusterId,
+            Arg.Any<CancellationToken>()).Returns(cluster);
+
+        using var cts = new CancellationTokenSource();
+        var token = cts.Token;
+
+        // Act
+        await _handler.Handle(NameCommand, token);
+
+        // Assert
+        await _clusterRepositoryMock.Received(1).GetByIdAsync(ClusterId, token);
+        await _unitOfWorkMock.Received(1).SaveChangesAsync(token);
+    }
+}

--- a/tests/EnvironmentGateway/EnvironmentGateway.Application.UnitTests/Clusters/ChangeClusterNameTests.cs
+++ b/tests/EnvironmentGateway/EnvironmentGateway.Application.UnitTests/Clusters/ChangeClusterNameTests.cs
@@ -5,7 +5,7 @@ using FluentAssertions;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 
-namespace EnvironmentGateway.Application.UnitTests;
+namespace EnvironmentGateway.Application.UnitTests.Clusters;
 
 public class ChangeClusterNameTests
 {

--- a/tests/EnvironmentGateway/EnvironmentGateway.Application.UnitTests/EnvironmentGateway.Application.UnitTests.csproj
+++ b/tests/EnvironmentGateway/EnvironmentGateway.Application.UnitTests/EnvironmentGateway.Application.UnitTests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" >
+    <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="xunit" />
-    <PackageReference Include="xunit.runner.visualstudio" >
+    <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/EnvironmentGateway/EnvironmentGateway.Domain.UnitTests/Clusters/ClustersTests.cs
+++ b/tests/EnvironmentGateway/EnvironmentGateway.Domain.UnitTests/Clusters/ClustersTests.cs
@@ -67,4 +67,31 @@ public class ClustersTests
         Action act = () => cluster.AddDestination(newDestination!);
         act.Should().Throw<ArgumentNullException>();
     }
+
+    [Fact]
+    public void ChangeName_Should_ChangeClusterName()
+    {
+        // Arrange
+        var cluster = Cluster.Create(TestClusterName, TestDestinationName, TestDestinationAddress);
+        var newName = "newClusterName";
+
+        // Act
+        cluster.ChangeName(newName);
+
+        // Assert
+        cluster.ClusterName.Value.Should().Be(newName);
+    }
+
+    [Fact]
+    public void ChangeName_Should_ThrowArgumentNullException_When_NameIsNull()
+    {
+        // Arrange
+        var cluster = Cluster.Create(TestClusterName, TestDestinationName, TestDestinationAddress);
+
+        // Act
+        Action act = () => cluster.ChangeName(null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>();
+    }
 }


### PR DESCRIPTION
This pull request adds a new feature to allow changing the name of a cluster via an API endpoint, including full validation, domain logic, persistence, and comprehensive test coverage. The implementation introduces new application, domain, and infrastructure components, and updates test suites to verify correct behavior and error handling.

**API and Application Layer:**

* Added a new `PUT` endpoint (`ChangeClusterName`) for updating a cluster's name, which validates input, handles errors, and updates runtime configuration after a successful change (`ChangeClusterName.cs`, `ChangeClusterNameRequest.cs`). [[1]](diffhunk://#diff-82a94097ac66858a15682d5ca6d2387def4816a3cc559f8fd6ab9de42d8b80fdR1-R37) [[2]](diffhunk://#diff-e2032cf14b460b947521f3e41cbb66ae9772e78efc1f65b07449bd42128dc10eR1-R5)
* Implemented the command (`ChangeClusterNameCommand.cs`) and its handler (`ChangeClusterNameCommandHandler.cs`) to encapsulate and process the cluster name change logic. [[1]](diffhunk://#diff-74f3e8139439589835998a2b868586d4bf08d4f806ca45b998dbe0876700a608R1-R8) [[2]](diffhunk://#diff-e8e675bc6d000be536e1c32262e3402383ec9515fbf8a36941792024556fb445R1-R30)
* Introduced a validator to enforce cluster name rules: only letters, numbers, and hyphens allowed, max length 100, no spaces or special characters (`ChangeClusterNameValidator.cs`).

**Domain and Infrastructure Layer:**

* Added the `ChangeName` method to the `Cluster` entity, allowing its name to be changed and enforcing immutability on the `ClusterName` property (`Cluster.cs`). [[1]](diffhunk://#diff-4fe7e2f2dcdab7ca56ceffcacbf17440f64f4bbe5328f77d9c9530989c465908L22-R22) [[2]](diffhunk://#diff-4fe7e2f2dcdab7ca56ceffcacbf17440f64f4bbe5328f77d9c9530989c465908R47-R53)
* Defined error handling for clusters not found (`ClusterErrors.cs`) and created the `IClusterRepository` interface and its implementation (`ClusterRepository.cs`). Registered the repository in dependency injection (`ClusterErrors.cs`, `IClusterRepository.cs`, `ClusterRepository.cs`, `DependencyInjection.cs`). [[1]](diffhunk://#diff-f8f40a7d5790f9a27260076f3b94b0e7e2fb3e06f82ec81ec01d56f9554b6796R1-R10) [[2]](diffhunk://#diff-f72797721985faeb62e532f90dd9f00375f4d6777d31d0eeb6b89200c68d4730R1-R8) [[3]](diffhunk://#diff-4797fa537932727c487584307e901d1db8381455f962b734e51bddd201375719R1-R10) [[4]](diffhunk://#diff-8edd86836b22708886350960321a46d55c41749fae61dba6d8c4cac9ff87ca7eR4) [[5]](diffhunk://#diff-8edd86836b22708886350960321a46d55c41749fae61dba6d8c4cac9ff87ca7eR55-R56)

**Testing:**

* Added functional, integration, and unit tests to ensure the endpoint and domain logic work correctly, including success, validation failure, error propagation, and cancellation token handling (`ChangeClusterNameTests.cs` in API, Application Integration, and Application Unit tests). [[1]](diffhunk://#diff-be404580de8baec7b0d919cde4be8b93859349063e4758b7870da8226baf96c5R1-R70) [[2]](diffhunk://#diff-faadd1bdaa8bb7ac2c00181b8259e674b392c1367604b3318e42c4afecd19027R1-R56) [[3]](diffhunk://#diff-043e8c79ae8ea46324ef57d8db3b77f5e904702192f0c306ac5c73e8c7f64c00R1-R122)
* Updated domain unit tests to cover the new `ChangeName` method and its error handling (`ClustersTests.cs`).
* Improved test infrastructure reliability by ensuring containers are started/stopped correctly and using proper wait strategies (`FunctionalTestWebAppFactory.cs`). [[1]](diffhunk://#diff-45e698eece898a8f7184591e14d4dc8a5a6da47ad36a6660900bf333e6f83768R15-R26) [[2]](diffhunk://#diff-45e698eece898a8f7184591e14d4dc8a5a6da47ad36a6660900bf333e6f83768R37-R51) [[3]](diffhunk://#diff-45e698eece898a8f7184591e14d4dc8a5a6da47ad36a6660900bf333e6f83768L73-R92)